### PR TITLE
fix: re-spin should remove previous votes 

### DIFF
--- a/api/actions.ts
+++ b/api/actions.ts
@@ -330,6 +330,7 @@ export async function handleRespin(
   const updatedGame = {
     ...game,
     spins: spins + 1,
+    votes: [],
     currentOptions: newSelectedRestaurants,
     possibleOptions: remainingOptions,
   } as GameState;


### PR DESCRIPTION
After a re-spin, remove any previous votes before updating the GameState.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated game behavior so that all previous votes are automatically cleared when a respin occurs, ensuring each new round starts with a clean slate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->